### PR TITLE
[usb] Charging works also after first plugin.

### DIFF
--- a/drivers/usb/otg/twl4030-usb.c
+++ b/drivers/usb/otg/twl4030-usb.c
@@ -516,7 +516,8 @@ static irqreturn_t twl4030_usb_irq(int irq, void *_twl)
 		 * USB_LINK_VBUS state.  musb_hdrc won't care until it
 		 * starts to handle softconnect right.
 		 */
-		if (status == USB_EVENT_NONE)
+		/* do not suspend if we have vbus */
+		if (status == USB_EVENT_NONE && !twl->vbus_supplied)
 			twl4030_phy_suspend(twl, 0);
 		else
 			twl4030_phy_resume(twl);


### PR DESCRIPTION
After the first plugin everything works, however unplug
and nothing works anymore until reboot. This patch seems
to at least re-enable charging. So the problem is most
likely related to some suspend-resume issue in the driver.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
